### PR TITLE
Moved to github actions, removed travis

### DIFF
--- a/.github/COMMIT_TEMPLATE/commitmessage.txt
+++ b/.github/COMMIT_TEMPLATE/commitmessage.txt
@@ -1,0 +1,11 @@
+Short Summary
+
+Why:
+
+* Reason 1
+* Reason 2
+
+What:
+
+* Change 1
+* Change 2

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,23 @@
+Short summary of your changes
+
+**Reasons:**
+
+- It's faster
+- It's a new feature
+
+**Changes:**
+
+- Altered Pom.xml
+- Upgraded Docker-Image Version
+
+**Possible Risks:**
+
+Mention any possible Risk to come up with
+
+**Related Issues:**
+
+Mention any related issue
+
+**Additional Info:**
+
+Feel free to add Screenshots, blame persons

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+Test:
+- src/test/*
+
+Documentation:
+- *.md
+
+Configuration:
+- .github/*.yml
+- .github/*.yaml
+- .github/**/*.yml
+- .github/**/*.yaml
+- .github/workflow/*
+- ./**/*.yml
+- ./**/*.yaml
+- ./**/*.json
+- ./**/*.xml
+- .gitignore
+- config.json
+
+
+Git:
+- .github/*
+- .gitignore

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+**Short Summary of your changes**
+
+**Reasons:**
+
+Why did you do this change?
+- It's faster
+- It's a new feature
+
+**Changes:**
+
+What did you change? 
+- Altered Pom.xml
+- Upgraded Docker-Image Version
+
+**Possible Risks:**
+
+Mention any possible Risk to come up with
+
+**Related Issues:**
+
+Mention any related issue
+ 
+
+**Additional Info:**
+
+Feel free to add Screenshots, blame persons

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,25 @@
+name: Auto merge Dependabot updates
+
+on:
+  check_suite:
+    types:
+      - completed
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto-merge
+        uses: ridedott/dependabot-auto-merge-action@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greeter.yml
+++ b/.github/workflows/greeter.yml
@@ -1,0 +1,13 @@
+name: "Greet Newcomers"
+
+on: [issues,pull_request]
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Hey there! Thanks for Contributing! Please take the time until I have a look to check whether the appropriate labels are set!'
+        pr-message: 'Thank you for Contributing! Take the time until I check your appreciated Pull Request to see if any labels are missing and watch the pipeline :) '

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -1,0 +1,19 @@
+name: Java CI
+
+on: 
+  pull_request:
+    branches: 
+      - master
+      - dev
+
+jobs:
+  buildFromMaven:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+    - name: Build with Maven  
+      run: mvn package verify

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches: 
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+  schedule:
+  - cron: "0 0 * * *"
+
+name: Credentials Check
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+    - name: Security Check with TruffleHog
+      run: |
+        pip install trufflehog
+        
+        echo "\.github/.*" > exclude.txt
+
+        trufflehog --regex --entropy=False -x="exclude.txt" https://Twonki:${TRUFFLEHOG_TOKEN}@github.com/Twonki/Microtope.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-jdk: openjdk12
-
-os:
-  - linux
-  - osx
-
-install: true
-script: mvn clean install


### PR DESCRIPTION
Reason: 

Github actions are nicer, and really much faster. 
Also closer possibilities to tie it to github releases. 

Changes:
- Added Github Templates for Issues and Utility Actions
- Added Github Maven Action 
- Removed Travis Action
